### PR TITLE
Updated linear-converter to version 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "should": "5.2.0"
   },
   "dependencies": {
-    "linear-converter": "6.0.4"
+    "linear-converter": "7.0.0"
   }
 }

--- a/src/linear-preset-any-to-any.js
+++ b/src/linear-preset-any-to-any.js
@@ -8,8 +8,8 @@ module.exports = function anyToAnyFactory(Decimal) {
   var lc = lcFactory(Decimal);
 
   return function anyToAny(conversions, fromUnit, destUnit) {
-    return lc.composePresets(
-      lc.invertPreset(conversions[fromUnit]),
+    return lc.composeConversions(
+      lc.invertConversion(conversions[fromUnit]),
       conversions[destUnit]
     );
   };


### PR DESCRIPTION
:rocket:

linear-converter just published version 7.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 3 commits (ahead by 3, behind by 0).
- [4f8b27a](https://github.com/javiercejudo/linear-converter/commit/4f8b27aa7fade79a16ad58ac88c6c07a01ea43fc): 7.0.0
- [c2f9705](https://github.com/javiercejudo/linear-converter/commit/c2f97059c6783b4f454d2771e885fce76372b0f6): Merge pull request #22 from javiercejudo/api-changes
- [b9e7745](https://github.com/javiercejudo/linear-converter/commit/b9e77450b64a32d599a69d01beb8e9407746f51e): feat(api): rename api methods to replace preset with conversion

See the [full diff](https://github.com/javiercejudo/linear-converter/compare/6009910159ff1e5fe2242a40ec0d29f2b16dc896...4f8b27aa7fade79a16ad58ac88c6c07a01ea43fc).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
