### PR TITLE
Updated linear-converter to version 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "should": "5.2.0"
   },
   "dependencies": {
-    "linear-converter": "7.0.0"
+    "linear-converter": "7.0.1"
   }
 }


### PR DESCRIPTION
:rocket:

linear-converter just published version 7.0.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 2 commits (ahead by 2, behind by 0).
- [fab0e7d](https://github.com/javiercejudo/linear-converter/commit/fab0e7d15e7d139ad8326e4ed504d0d3b5e9e48d): 7.0.1
- [1640c8e](https://github.com/javiercejudo/linear-converter/commit/1640c8e1c88c434cd114c4eeefc134ff912dc64f): docs(README): add link to linear-presets after first example

See the [full diff](https://github.com/javiercejudo/linear-converter/compare/4f8b27aa7fade79a16ad58ac88c6c07a01ea43fc...fab0e7d15e7d139ad8326e4ed504d0d3b5e9e48d).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
